### PR TITLE
feat: Add custom dark and light themes for mermaid diagrams

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -117,6 +117,37 @@ export default async function createConfig() {
     themeConfig:
       /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
       ({
+        mermaid: {
+          theme: { light: 'base', dark: 'base' },
+          config: {
+            dark: {
+              theme: 'base',
+              themeVariables: {
+                primaryColor: '#426367',
+                background: '#856c6b',
+                primaryBorderColor: '#426367',
+                tertiaryBorderColor: '#7a9394',
+                tertiaryTextColor: '#7a9394',
+                secondaryColor: '#778f91',
+                tertiaryColor: '#002026',
+                primaryTextColor: '#d6eeee',
+              },
+            },
+            light: {
+              theme: 'base',
+              themeVariables: {
+                primaryColor: '#ebf0f0',
+                background: '#1c1e1e',
+                primaryBorderColor: '#d5e1e1',
+                tertiaryBorderColor: '#d5e1e1',
+                tertiaryTextColor: '#426367',
+                secondaryColor: '#dee7e7',
+                tertiaryColor: '#ffffff',
+                primaryTextColor: '#426367',
+              },
+            },
+          },
+        },
         docs: {
           sidebar: {
             autoCollapseCategories: true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@docusaurus/plugin-sitemap": "^3.4.0",
     "@docusaurus/preset-classic": "^3.4.0",
     "@docusaurus/theme-common": "^3.4.0",
-    "@docusaurus/theme-mermaid": "^3.4.0",
+    "@docusaurus/theme-mermaid": "npm:@sidv/docusaurus-theme-mermaid@beta",
     "@docusaurus/theme-search-algolia": "^3.4.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,10 +2404,10 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-mermaid@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.4.0.tgz#ef1d2231d0858767f67538b4fafd7d0ce2a3e845"
-  integrity sha512-3w5QW0HEZ2O6x2w6lU3ZvOe1gNXP2HIoKDMJBil1VmLBc9PmpAG17VmfhI/p3L2etNmOiVs5GgniUqvn8AFEGQ==
+"@docusaurus/theme-mermaid@npm:@sidv/docusaurus-theme-mermaid@beta":
+  version "3.5.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sidv/docusaurus-theme-mermaid/-/docusaurus-theme-mermaid-3.5.0-beta.1.tgz#051971ce95bc365991e5efeddfd0b3ea863fc48f"
+  integrity sha512-gFYlyJZ8QhZZ+XoqUkXOABDg8eVUwv5XvZvQ4GFIgDsHAoslGIo8I2CkcKy+8x3Xc2PCpir0u//zPfDupeFBUQ==
   dependencies:
     "@docusaurus/core" "3.4.0"
     "@docusaurus/module-type-aliases" "3.4.0"


### PR DESCRIPTION
Uses modified version of docusaurus-theme-mermaid to support different theme variables for dark and light modes.

RFC for adding the feature to docusaurus is ongoing
https://github.com/facebook/docusaurus/issues/10251
