### PR TITLE
fix: change hyperlinks to components repository

### DIFF
--- a/docs/stack/architecture.mdx
+++ b/docs/stack/architecture.mdx
@@ -41,15 +41,15 @@ The data plane is composed of a number of components that work together to provi
 
 | Name          | License | Source available | Group    | Repository |
 |---------------|---------|------------------|---------|------------|
-| Ledger        | MIT     | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/components/ledger) |
-| Payments      | MIT     | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/components/payments) |
-| Orchestration | EE      | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/ee/orchestration) |
-| Wallets       | EE     | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/ee/wallets) |
-| Reconciliation      | EE    | Yes              | Product  | [Github](https://github.com/formancehq/stack/tree/main/ee/reconciliation) |
-| Search        | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/search) |
-| Auth          | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/auth) |
-| Gateway       | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/gateway) |
-| Webhooks      | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/webhooks) |
-| Stargate      | EE    | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/stargate) |
+| Ledger        | MIT     | Yes              | Product | [Github](https://github.com/formancehq/ledger) |
+| Payments      | MIT     | Yes              | Product | [Github](https://github.com/formancehq/payments) |
+| Orchestration (flows) | EE      | Yes              | Product | [Github](https://github.com/formancehq/flows) |
+| Wallets       | EE     | Yes              | Product | [Github](https://github.com/formancehq/wallets) |
+| Reconciliation      | EE    | Yes              | Product  | [Github](https://github.com/formancehq/reconciliation) |
+| Search        | EE     | Yes              | System  | [Github](https://github.com/formancehq/search) |
+| Auth          | EE     | Yes              | System  | [Github](https://github.com/formancehq/auth) |
+| Gateway       | EE     | Yes              | System  | [Github](https://github.com/formancehq/gateway) |
+| Webhooks      | EE     | Yes              | System  | [Github](https://github.com/formancehq/webhooks) |
+| Stargate      | EE    | Yes              | System  | [Github](https://github.com/formancehq/stargate) |
 
 ### Dependencies

--- a/versioned_docs/version-v1.10/stack/architecture.mdx
+++ b/versioned_docs/version-v1.10/stack/architecture.mdx
@@ -41,14 +41,15 @@ The data plane is composed of a number of components that work together to provi
 
 | Name          | License | Source available | Group    | Repository |
 |---------------|---------|------------------|---------|------------|
-| Ledger        | MIT     | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/components/ledger) |
-| Payments      | MIT     | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/components/payments) |
-| Orchestration | EE      | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/ee/orchestration) |
-| Wallets       | EE     | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/ee/wallets) |
-| Search        | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/search) |
-| Auth          | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/auth) |
-| Gateway       | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/gateway) |
-| Webhooks      | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/webhooks) |
-| Stargate      | EE    | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/stargate) |
+| Ledger        | MIT     | Yes              | Product | [Github](https://github.com/formancehq/ledger) |
+| Payments      | MIT     | Yes              | Product | [Github](https://github.com/formancehq/payments) |
+| Orchestration (flows) | EE      | Yes              | Product | [Github](https://github.com/formancehq/flows) |
+| Wallets       | EE     | Yes              | Product | [Github](https://github.com/formancehq/wallets) |
+| Reconciliation      | EE    | Yes              | Product  | [Github](https://github.com/formancehq/reconciliation) |
+| Search        | EE     | Yes              | System  | [Github](https://github.com/formancehq/search) |
+| Auth          | EE     | Yes              | System  | [Github](https://github.com/formancehq/auth) |
+| Gateway       | EE     | Yes              | System  | [Github](https://github.com/formancehq/gateway) |
+| Webhooks      | EE     | Yes              | System  | [Github](https://github.com/formancehq/webhooks) |
+| Stargate      | EE    | Yes              | System  | [Github](https://github.com/formancehq/stargate) |
 
 ### Dependencies

--- a/versioned_docs/version-v2.x/stack/architecture.mdx
+++ b/versioned_docs/version-v2.x/stack/architecture.mdx
@@ -41,15 +41,15 @@ The data plane is composed of a number of components that work together to provi
 
 | Name          | License | Source available | Group    | Repository |
 |---------------|---------|------------------|---------|------------|
-| Ledger        | MIT     | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/components/ledger) |
-| Payments      | MIT     | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/components/payments) |
-| Orchestration | EE      | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/ee/orchestration) |
-| Wallets       | EE     | Yes              | Product | [Github](https://github.com/formancehq/stack/tree/main/ee/wallets) |
-| Reconciliation      | EE    | Yes              | Product  | [Github](https://github.com/formancehq/stack/tree/main/ee/reconciliation) |
-| Search        | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/search) |
-| Auth          | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/auth) |
-| Gateway       | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/gateway) |
-| Webhooks      | EE     | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/webhooks) |
-| Stargate      | EE    | Yes              | System  | [Github](https://github.com/formancehq/stack/tree/main/ee/stargate) |
+| Ledger        | MIT     | Yes              | Product | [Github](https://github.com/formancehq/ledger) |
+| Payments      | MIT     | Yes              | Product | [Github](https://github.com/formancehq/payments) |
+| Orchestration (flows) | EE      | Yes              | Product | [Github](https://github.com/formancehq/flows) |
+| Wallets       | EE     | Yes              | Product | [Github](https://github.com/formancehq/wallets) |
+| Reconciliation      | EE    | Yes              | Product  | [Github](https://github.com/formancehq/reconciliation) |
+| Search        | EE     | Yes              | System  | [Github](https://github.com/formancehq/search) |
+| Auth          | EE     | Yes              | System  | [Github](https://github.com/formancehq/auth) |
+| Gateway       | EE     | Yes              | System  | [Github](https://github.com/formancehq/gateway) |
+| Webhooks      | EE     | Yes              | System  | [Github](https://github.com/formancehq/webhooks) |
+| Stargate      | EE    | Yes              | System  | [Github](https://github.com/formancehq/stargate) |
 
 ### Dependencies


### PR DESCRIPTION
The components repository contained outdated links pointing to invalid URLs. This PR updates those URLs to reference the new repositories. No functional changes were made—only URL corrections to ensure proper linkage.